### PR TITLE
Bugfix: Clear parser interval

### DIFF
--- a/src/helpers/scheduler.ts
+++ b/src/helpers/scheduler.ts
@@ -74,6 +74,8 @@ export class Scheduler {
     if (indexToDelete < 0 || indexToDelete > this.parsers.length) {
       return;
     }
+    clearInterval(this.parsers[indexToDelete]?.intervalFunction);
     this.parsers.splice(indexToDelete, 1);
+    logger.info(`Deleted parser id: ${id}`);
   }
 }

--- a/src/parsers/tori.ts
+++ b/src/parsers/tori.ts
@@ -39,7 +39,7 @@ export class Tori extends Parser {
     }
 
     // For testing
-    //this.previousParseResults.splice(0, 1);
+    // this.previousParseResults.splice(0, 1);
 
     const newProducts = products.filter(
       (p) => !this.previousParseResults.includes(p.id)


### PR DESCRIPTION
Before, parser was deleted but instance was still run in the background. Added `clearInterval` to delete the process.